### PR TITLE
Update banbong.css

### DIFF
--- a/Web_ver1/assets/CSS/banbong.css
+++ b/Web_ver1/assets/CSS/banbong.css
@@ -1,18 +1,38 @@
-body, html{
-    margin: 0;
-    height: 100vh;
-    background: linear-gradient(-45deg, #204, #000);
-    overflow: hidden;
-  }
-  #c:focus{
-    outline: none;
-  }
-  #c{
-    border: 3px solid #0Ff3;
-    position: absolute;
-    background: #04f1;
-    left: 50%;
-    top: 50%;
-    border-radius: 10px;
-    transform: translate(-50%, -50%);
-  }                                                     
+/* A simple reset/cleanup for margin and padding */
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  /* Use a linear gradient for background */
+  background: linear-gradient(-45deg, #220044, #000000);
+  overflow: hidden;
+  font-family: sans-serif;
+}
+
+/* Remove the default focus outline from the #c element */
+#c:focus {
+  outline: none;
+}
+
+/* Center a box in the middle of the screen with a neon border style */
+#c {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  /* Subtle semi-transparent background */
+  background: rgba(0, 255, 255, 0.06);
+
+  /* Brighter neon border */
+  border: 3px solid #0ff;
+  border-radius: 10px;
+
+  /* Optional transition to animate changes smoothly (e.g., on hover) */
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+/* Hover state for a subtle interactive feel */
+#c:hover {
+  background: rgba(0, 255, 255, 0.1);
+  border-color: #0ff8;
+}


### PR DESCRIPTION
Below is a refined version of your CSS snippet. The functionality remains (full-page gradient, centered element), but it’s now slightly more polished with consistent color usage, minor resets, and optional transitions to improve the user experience:

Explanation of Key Tweaks:
Gradient Colors

Adjusted them to #220044 and #000000 for a clearer dark scheme (feel free to tweak the exact hex values). Consistent Hex Notation

Switched to #0ff or #0ff8 for a neat neon-cyan border. Replaced the slightly ambiguous #0Ff3.
Transitions

Added a transition property on #c so any future style changes happen smoothly (e.g., on hover). Hover State

Provided a small interactive effect to highlight the box when hovered. Minor Reset

padding: 0 on html, body, plus a font-family to ensure a clean base.